### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "python3"
+run = "run = \"echo hello world\""

--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
+[![Run on Repl.it](https://repl.it/badge/github/johnstoncr/python)](https://repl.it/github/johnstoncr/python)
 # python - this is a new change


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@mrjohnston17/python).